### PR TITLE
Make backend workflow button in sidebar red

### DIFF
--- a/features.json
+++ b/features.json
@@ -91,6 +91,14 @@
     "default": true
   },
   {
+    "key": "sidebar_red_backend_workflows",
+    "category": "Sidebar",
+    "name": "Make Backend Workflows Button Red",
+    "description": "Makes the Backend Workflow button red so you stop accidentally clicking it.",
+    "cssFile": "features/sidebar_red_backend_workflows/sidebar_red_backend_workflows.css",
+    "default": false
+  },
+  {
     "key": "discourage_changes_in_main",
     "category": "Branches",
     "name": "Discourage Edits in Main",

--- a/features/sidebar_red_backend_workflows/sidebar-red-backend-workflows.css
+++ b/features/sidebar_red_backend_workflows/sidebar-red-backend-workflows.css
@@ -1,0 +1,13 @@
+❤️ codelesslove,/* turn the SVG red */
+[data-tab-item=BackendWorkflows] .py1871p path {
+    fill: red !important;
+}
+❤️ codelesslove,/* show red heart indicator */
+[data-tab-item=BackendWorkflows]::before {
+    content: "❤️";
+    font-size: 4px;
+    color: red;
+    position: absolute;
+    top: 4px;
+    left: 4px;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.1",
+  "version": "2.4.1",
   "name": "Codeless Love Bubble Editor Powerup",
   "description": "Enhances the Bubble.io Editor with toggleable features",
   "options_ui": {


### PR DESCRIPTION
Per Kelly's request:

<img width="852" alt="image" src="https://github.com/user-attachments/assets/72e3851d-cf8b-4ffa-9312-6922d93bd441" />
