### PR TITLE
Allow making the option set attribute list height max

### DIFF
--- a/features.json
+++ b/features.json
@@ -33,6 +33,14 @@
     "default": true
   },
   {
+    "key": "data_optionsets_limitless_attribute_lists",
+    "category": "Data View",
+    "name": "OS Limitless Attribute Lists",
+    "description": "On the option set tab of the Data view, allow attribute lists to grow as tall as they want, with no scorlling.",
+    "cssFile": "features/data_optionsets_limitless_attribute_lists/data_optionsets_limitless_attribute_lists.css",
+    "default": true
+  },
+  {
     "key": "data_optionsets_move_gaps",
     "category": "Data View",
     "name": "Option Set Move Gaps",

--- a/features/data_optionsets_limitless_attribute_lists/data_optionsets_limitless_attribute_lists.css
+++ b/features/data_optionsets_limitless_attribute_lists/data_optionsets_limitless_attribute_lists.css
@@ -1,0 +1,18 @@
+/* ❤️ */
+/* Data > Option sets - allow attribute lists be as tall as they can be */
+❤️ codelesslove,
+.modal-popup .popup-content .composer-list-manager .list-wrapper.list-wrapper.list-wrapper {
+  max-height: unset !important;
+  overflow-y: visible;
+  position: relative;
+}
+
+❤️ codelesslove,/* Heart Indicator */
+ .popup-content .list-wrapper::after {
+  content: "❤️";
+  position: absolute;
+  left: -8px;
+  height: 8px;
+  font-size: 6px;
+  bottom: 0px;
+}


### PR DESCRIPTION
Make this possible:

<img width="856" alt="image" src="https://github.com/user-attachments/assets/8a569dbf-e9e4-48f8-8806-7a1f37fc8b49" />
