### PR TITLE
add the version to the tab name

### DIFF
--- a/features.json
+++ b/features.json
@@ -9,6 +9,14 @@
     "default": false
   },
   {
+    "key": "tab_naming",
+    "category": "Branches",
+    "name": "Tab Naming",
+    "description": "Automatically renames the Chrome tab to display the current branch name from the version URL parameter. Makes it easier to identify which branch you're working on when multiple editor tabs are open.",
+    "jsFile": "features/tab_naming/tab_naming.js",
+    "default": false
+  },
+  {
     "key": "privacy_button_red_public",
     "category": "Privacy",
     "name": "Privacy Status Badges",

--- a/features/tab_naming/tab_naming.js
+++ b/features/tab_naming/tab_naming.js
@@ -1,0 +1,50 @@
+window.loadedCodelessLoveScripts ||= {};
+(function () {
+    console.log("❤️" + "Tab Naming");
+    let thisScriptKey = "tab_naming";
+
+    /* ------------------------------------------------ */
+    /* ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ Don't mess with this  ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ */
+    /* ------------------------------------------------ */
+    if (window.loadedCodelessLoveScripts[thisScriptKey] == "loaded") {
+        console.warn("❤️" + thisScriptKey + " tried to load, but it's value is already " + window.loadedCodelessLoveScripts[thisScriptKey]);
+        return;
+    }
+    window.loadedCodelessLoveScripts[thisScriptKey] = "loaded";
+    console.log("❤️" + window.loadedCodelessLoveScripts[thisScriptKey]);
+    /* ------------------------------------------------ */
+    /* ⬆️ ⬆️ ⬆️ ⬆️ ⬆️ Don't mess with this  ⬆️ ⬆️ ⬆️ ⬆️ ⬆️ */
+    /* ------------------------------------------------ */
+
+    // Store the original title
+    const originalTitle = document.title;
+
+    // Utility to extract query parameters from the URL
+    function getQueryParam(param) {
+        const url = new URL(window.location.href);
+        return url.searchParams.get(param);
+    }
+
+    // Function to update the tab title with the branch name
+    function updateTabTitle() {
+        const version = getQueryParam("version");
+
+        document.title = `${version} | ${originalTitle}`;
+        console.log("❤️" + "Tab title updated with branch name: " + version);
+    }
+
+    // Watch for changes in the URL (for SPAs)
+    let lastUrl = window.location.href;
+    const observer = new MutationObserver(() => {
+        if (lastUrl !== window.location.href) {
+            lastUrl = window.location.href;
+            updateTabTitle();
+        }
+    });
+
+    // Start observing changes to the document body
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    // Run on initial load
+    updateTabTitle();
+})();


### PR DESCRIPTION
You can now rename the Chrome tab name with the version.

<img width="1430" height="132" alt="CleanShot 2025-10-04 at 05 25 41@2x" src="https://github.com/user-attachments/assets/40f8782e-ff8c-4dea-9bcc-807b20ddee5c" />
