### PR TITLE
Add Delete Unused Colors

### DIFF
--- a/features.json
+++ b/features.json
@@ -28,7 +28,7 @@
     "default": true,
     "contributors": ["george"]
   },
-{
+  {
     "key": "left_to_right_action_view",
     "category": "Workflow View",
     "name": "Wrap Actions Left-to-Right",
@@ -407,5 +407,15 @@
     "jsFile": "features/styles-drag-rearrange/styles-drag-rearrange.js",
     "default": true,
     "contributors": ["rico"]
+  },
+  {
+    "key": "delete_unused_colors",
+    "category": "Style Tab",
+    "name": "Delete unused colors",
+    "description": "List and delete color variables unused in the app",
+    "cssFile": "features/delete_unused_colors/delete_unused_colors.css",
+    "jsFile": "features/delete_unused_colors/delete_unused_colors.js",
+    "default": false,
+    "contributors": ["thomas"]
   }
 ]

--- a/features.json
+++ b/features.json
@@ -415,7 +415,7 @@
     "description": "List and delete color variables unused in the app",
     "cssFile": "features/delete_unused_colors/delete_unused_colors.css",
     "jsFile": "features/delete_unused_colors/delete_unused_colors.js",
-    "default": false,
+    "default": true,
     "contributors": ["thomas"]
   }
 ]

--- a/features/delete_unused_colors/delete_unused_colors.css
+++ b/features/delete_unused_colors/delete_unused_colors.css
@@ -1,0 +1,322 @@
+/* Delete unused colors — extension popup UI */
+
+.delete-unused-colors-tool.tool-section {
+  margin-left: 28px;
+}
+
+.delete-unused-colors-tool.tool-section > p {
+  margin-left: 0;
+}
+
+.duc-scan-btn {
+  padding: 8px 16px;
+  border: none;
+  border-radius: var(--border-radius, 8px);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  background: var(--primary-color, #4361ee);
+  color: #fff;
+}
+
+.duc-scan-btn:hover:not(:disabled) {
+  background: var(--primary-hover, #3a56d4);
+}
+
+.duc-scan-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.duc-inline-message {
+  margin-top: 10px;
+  padding: 8px 10px;
+  font-size: 13px;
+  line-height: 1.4;
+  border-radius: 6px;
+}
+
+.duc-inline-message[hidden] {
+  display: none !important;
+}
+
+.duc-inline-message--success {
+  color: var(--success-color, #10b981);
+  background: rgba(16, 185, 129, 0.1);
+  border: 1px solid rgba(16, 185, 129, 0.35);
+}
+
+.duc-inline-message--error {
+  color: var(--danger-color, #ef4444);
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+}
+
+.duc-scan-loader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+  padding: 10px 12px;
+  border-radius: var(--border-radius, 8px);
+  background: var(--secondary-color, #f8f9fa);
+  border: 1px solid var(--border-color, #e9ecef);
+  font-size: 13px;
+  color: var(--text-secondary, #6c757d);
+}
+
+.duc-scan-loader[hidden] {
+  display: none !important;
+}
+
+.duc-scan-loader-spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--border-color, #e9ecef);
+  border-top-color: var(--primary-color, #4361ee);
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: duc-spin 0.7s linear infinite;
+}
+
+@keyframes duc-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+#duc-app-raw-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+#duc-app-raw-modal[hidden] {
+  display: none !important;
+}
+
+.duc-app-raw-dialog {
+  position: relative;
+  background: var(--card-background, #fff);
+  border-radius: var(--border-radius, 8px);
+  box-shadow: 0 12px 40px var(--shadow-color, rgba(0, 0, 0, 0.08));
+  max-width: 100%;
+  width: min(560px, 100%);
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-color, #e9ecef);
+}
+
+.duc-confirm-overlay {
+  position: absolute;
+  inset: -1px;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: var(--border-radius, 8px);
+}
+
+.duc-confirm-overlay[hidden] {
+  display: none !important;
+}
+
+.duc-confirm-dialog {
+  width: 100%;
+  max-width: 340px;
+  padding: 16px;
+  background: var(--card-background, #fff);
+  border-radius: var(--border-radius, 8px);
+  border: 1px solid var(--border-color, #e9ecef);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.duc-confirm-title {
+  margin: 0 0 10px;
+  font-size: 1.05em;
+  font-weight: 600;
+  color: var(--text-color, #212529);
+}
+
+.duc-confirm-message {
+  margin: 0 0 16px;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-secondary, #6c757d);
+}
+
+.duc-confirm-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.duc-app-raw-dialog > .duc-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px;
+  border-bottom: 1px solid var(--border-color, #e9ecef);
+  flex-shrink: 0;
+}
+
+.duc-app-raw-dialog > .duc-dialog-header h2 {
+  margin: 0;
+  padding: 0;
+  border: none;
+  font-size: 1.1em;
+  font-weight: 600;
+  color: var(--text-color, #212529);
+}
+
+.duc-dialog-body {
+  margin: 0;
+  padding: 12px;
+  overflow: auto;
+  overscroll-behavior: contain;
+  flex: 1;
+  min-height: 0;
+}
+
+.duc-modal-error {
+  margin: 0 0 10px;
+  padding: 10px;
+  font-size: 13px;
+  color: var(--danger-color, #ef4444);
+  background: rgba(239, 68, 68, 0.08);
+  border-radius: 6px;
+  border: 1px solid rgba(239, 68, 68, 0.25);
+}
+
+.duc-unused-section {
+  margin-bottom: 14px;
+}
+
+.duc-unused-heading {
+  margin: 0 0 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary, #6c757d);
+}
+
+.duc-unused-select-all-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: var(--secondary-color, #f8f9fa);
+  border: 1px solid var(--border-color, #e9ecef);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.duc-unused-select-all-wrap label {
+  cursor: pointer;
+  user-select: none;
+}
+
+.duc-unused-select-all-wrap input[type="checkbox"] {
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.duc-unused-list {
+  max-height: min(36vh, 280px);
+  overflow-y: auto;
+  border: 1px solid var(--border-color, #e9ecef);
+  border-radius: 6px;
+  background: var(--card-background, #fff);
+}
+
+.duc-unused-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-color, #e9ecef);
+  font-size: 13px;
+}
+
+.duc-unused-row:last-child {
+  border-bottom: none;
+}
+
+.duc-unused-row:hover {
+  background: var(--secondary-color, #f8f9fa);
+}
+
+.duc-unused-row input[type="checkbox"] {
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
+  margin: 2px 0 0;
+  flex-shrink: 0;
+}
+
+.duc-unused-row label {
+  cursor: pointer;
+  flex: 1;
+  line-height: 1.4;
+  user-select: none;
+}
+
+.duc-unused-empty {
+  margin: 0;
+  padding: 12px;
+  font-size: 13px;
+  color: var(--text-secondary, #6c757d);
+}
+
+.duc-app-raw-dialog > .duc-dialog-footer {
+  padding: 12px;
+  border-top: 1px solid var(--border-color, #e9ecef);
+  flex-shrink: 0;
+}
+
+.duc-dialog-footer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.duc-dialog-footer .row {
+  display: flex;
+  justify-content: center;
+}
+
+.duc-apply-btn {
+  padding: 8px 14px;
+  border: none;
+  border-radius: var(--border-radius, 8px);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  background: #e74c3c;
+  color: #fff;
+}
+
+.duc-apply-btn:hover:not(:disabled) {
+  background: #c0392b;
+}
+
+.duc-apply-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}

--- a/features/delete_unused_colors/delete_unused_colors.js
+++ b/features/delete_unused_colors/delete_unused_colors.js
@@ -1,0 +1,28 @@
+window.loadedCodelessLoveScripts ||= {};
+(function () {
+  console.log("❤️" + "Delete unused colors");
+  let thisScriptKey = "delete_unused_colors";
+
+  /* ------------------------------------------------ */
+  /* ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ Don't mess with this  ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ */
+  /* ------------------------------------------------ */
+  if (window.loadedCodelessLoveScripts[thisScriptKey] == "loaded") {
+    console.warn(
+      "❤️" +
+        thisScriptKey +
+        " tried to load, but it's value is already " +
+        window.loadedCodelessLoveScripts[thisScriptKey],
+    );
+    return;
+  }
+  window.loadedCodelessLoveScripts[thisScriptKey] = "loaded";
+  /* ------------------------------------------------ */
+  /* ⬆️ ⬆️ ⬆️ ⬆️ ⬆️ Don't mess with this  ⬆️ ⬆️ ⬆️ ⬆️ ⬆️ */
+  /* ------------------------------------------------ */
+
+  chrome.runtime.sendMessage({
+    action: "injectScriptIntoExtensionUIWorld",
+    jsFile: "features/delete_unused_colors/delete_unused_colors_popup.js",
+    cssFile: "features/delete_unused_colors/delete_unused_colors.css",
+  });
+})();

--- a/features/delete_unused_colors/delete_unused_colors_popup.js
+++ b/features/delete_unused_colors/delete_unused_colors_popup.js
@@ -1,0 +1,655 @@
+(function () {
+  console.log("❤️ Delete unused colors — popup module loaded");
+
+  // ── Feature container ─────────────────────────────────────────────────
+
+  const featureDiv = document
+    .getElementById("delete_unused_colors")
+    ?.closest(".feature");
+  if (!featureDiv) {
+    console.error(
+      "❤️ Delete unused colors: could not find feature container in popup.",
+    );
+    return;
+  }
+
+  // ── HTML Templates ────────────────────────────────────────────────────
+
+  const toolHtml = `
+    <div class="tool-section delete-unused-colors-tool">
+      <p style="color: var(--text-secondary); font-size: 13px; margin-bottom: 1em;">
+        First, preload your application using <strong>Optimize Application</strong> in Bubble's Settings. Then click Scan to detect and delete unused color variables.
+      </p>
+      <div id="duc-scan-loader" class="duc-scan-loader" hidden>
+        <span class="duc-scan-loader-spinner"></span>
+        <span>Scanning colors…</span>
+      </div>
+      <button type="button" id="duc-scan-app-button" class="duc-scan-btn">
+        Scan app
+      </button>
+      <div id="duc-inline-message" class="duc-inline-message" hidden></div>
+    </div>
+  `;
+  featureDiv.insertAdjacentHTML("beforeend", toolHtml);
+
+  const modalHtml = `
+    <div id="duc-app-raw-modal" hidden>
+      <div class="duc-app-raw-dialog" role="dialog" aria-labelledby="duc-app-raw-title" aria-modal="true">
+        <div id="duc-confirm-overlay" class="duc-confirm-overlay" hidden aria-hidden="true">
+          <div class="duc-confirm-dialog" role="alertdialog" aria-labelledby="duc-confirm-title" aria-describedby="duc-confirm-message">
+            <h3 id="duc-confirm-title" class="duc-confirm-title">Remove from variables?</h3>
+            <p id="duc-confirm-message" class="duc-confirm-message"></p>
+            <div class="duc-confirm-actions">
+              <button type="button" id="duc-confirm-cancel" class="button-secondary">Cancel</button>
+              <button type="button" id="duc-confirm-ok" class="duc-apply-btn">Remove</button>
+            </div>
+          </div>
+        </div>
+        <div class="duc-dialog-header">
+          <h2 id="duc-app-raw-title">Color Variables</h2>
+          <button type="button" class="button-secondary" id="duc-app-raw-close" aria-label="Close">Close</button>
+        </div>
+        <div class="duc-dialog-body">
+          <div id="duc-modal-error" class="duc-modal-error" hidden></div>
+          <div id="duc-modal-report" hidden>
+            <div id="duc-unused-section" class="duc-unused-section" hidden>
+              <h3 id="duc-unused-heading" class="duc-unused-heading">Unused colors</h3>
+              <div id="duc-unused-select-all-wrap" class="duc-unused-select-all-wrap" hidden>
+                <input type="checkbox" id="duc-unused-select-all" checked />
+                <label for="duc-unused-select-all">Select / unselect all</label>
+              </div>
+              <div id="duc-unused-list" class="duc-unused-list"></div>
+            </div>
+          </div>
+        </div>
+        <div class="duc-dialog-footer duc-dialog-footer-actions">
+          <button type="button" id="duc-apply-mark-deleted" class="duc-apply-btn" hidden>
+            Delete selected colors
+          </button>
+          <button type="button" id="duc-app-raw-close-footer" class="button-secondary">Close</button>
+        </div>
+      </div>
+    </div>
+  `;
+  document.body.insertAdjacentHTML("beforeend", modalHtml);
+
+  // ── DOM References ────────────────────────────────────────────────────
+
+  const scanBtn = document.getElementById("duc-scan-app-button");
+  const loader = document.getElementById("duc-scan-loader");
+  const inlineMessageEl = document.getElementById("duc-inline-message");
+
+  const modal = document.getElementById("duc-app-raw-modal");
+  const modalError = document.getElementById("duc-modal-error");
+  const modalReport = document.getElementById("duc-modal-report");
+  const unusedHeading = document.getElementById("duc-unused-heading");
+
+  const unusedSection = document.getElementById("duc-unused-section");
+  const unusedSelectAllWrap = document.getElementById(
+    "duc-unused-select-all-wrap",
+  );
+  const unusedSelectAll = document.getElementById("duc-unused-select-all");
+  const unusedList = document.getElementById("duc-unused-list");
+
+  const applyBtn = document.getElementById("duc-apply-mark-deleted");
+  const closeBtn = document.getElementById("duc-app-raw-close");
+  const closeFooter = document.getElementById("duc-app-raw-close-footer");
+
+  const confirmOverlay = document.getElementById("duc-confirm-overlay");
+  const confirmMessageEl = document.getElementById("duc-confirm-message");
+  const confirmCancelBtn = document.getElementById("duc-confirm-cancel");
+  const confirmOkBtn = document.getElementById("duc-confirm-ok");
+
+  // ── State ─────────────────────────────────────────────────────────────
+
+  let pendingDelete = null;
+  let lastAppRawForApply = null;
+  let inlineMessageTimer = null;
+
+  // ── Data helpers ──────────────────────────────────────────────────────
+
+  function getUserColorVariables(appRaw) {
+    const colorTokensUser =
+      appRaw?.raw?.settings?.client_safe?.color_tokens_user ??
+      appRaw?.settings?.client_safe?.color_tokens_user;
+    if (!colorTokensUser || typeof colorTokensUser !== "object") return null;
+    const defaultTokens = colorTokensUser.default;
+    return defaultTokens && typeof defaultTokens === "object"
+      ? defaultTokens
+      : null;
+  }
+
+  function buildAppRawWithoutUserColors(appRaw) {
+    try {
+      const clone = JSON.parse(JSON.stringify(appRaw));
+      if (clone.raw?.settings?.client_safe) {
+        delete clone.raw.settings.client_safe.color_tokens_user;
+      }
+      if (clone.settings?.client_safe) {
+        delete clone.settings.client_safe.color_tokens_user;
+      }
+      return JSON.stringify(clone);
+    } catch {
+      return JSON.stringify(appRaw);
+    }
+  }
+
+  function analyzeColorVariablesUsage(appRaw) {
+    const defaultTokens = getUserColorVariables(appRaw);
+    if (!defaultTokens) {
+      return {
+        error: "color_tokens_user.default not found in app raw.",
+        unused: [],
+        used: [],
+      };
+    }
+
+    const appWithoutTokens = buildAppRawWithoutUserColors(appRaw);
+    const unused = [];
+    const used = [];
+
+    for (const id of Object.keys(defaultTokens)) {
+      const token = defaultTokens[id];
+      if (token?.deleted) continue;
+      const entry = { id, name: token?.name != null ? token.name : "" };
+      if (appWithoutTokens.includes(`--color_${id}_`)) {
+        used.push(entry);
+      } else {
+        unused.push(entry);
+      }
+    }
+
+    return { unused, used };
+  }
+
+  function buildColorsVariablesSoftDeleted(appRawSnapshot, idsToDelete) {
+    const defaultTokens = getUserColorVariables(appRawSnapshot);
+    if (!defaultTokens) return null;
+
+    const updated = JSON.parse(JSON.stringify(defaultTokens));
+    for (const id of idsToDelete) {
+      if (updated[id]) {
+        updated[id].deleted = true;
+      }
+    }
+    return updated;
+  }
+
+  // ── MAIN-world functions ──────────────────────────────────────────────
+  // Injected into the Bubble editor tab via chrome.scripting.executeScript.
+  // They MUST be fully self-contained (no closure references).
+
+  function checkAppPreloaded() {
+    return window.appquery().app().json._ready_key.is_turned() === true;
+  }
+
+  function fetchAppRawInPage() {
+    var raw = window.appquery().app().json.raw();
+    if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
+      throw new Error("App raw is not a JSON object");
+    }
+    return raw;
+  }
+
+  async function runWriteColorVariablesInPage(updatedDefault) {
+    function getAppInfo() {
+      var params = new URLSearchParams(window.location.search);
+      return {
+        appname: params.get("id"),
+        app_version: params.get("version") || "test",
+      };
+    }
+
+    try {
+      if (!window.Lib || typeof window.Lib !== "function") {
+        return { ok: false, error: "Lib() not available" };
+      }
+
+      var info = getAppInfo();
+      if (!info.appname) {
+        return { ok: false, error: "Missing app id in URL" };
+      }
+
+      var sessionId = Date.now() + "x" + Math.floor(Math.random() * 1000000000);
+
+      var payload = {
+        v: 1,
+        appname: info.appname,
+        app_version: info.app_version,
+        changes: [
+          {
+            body: { "%d1": updatedDefault },
+            path_array: ["settings", "client_safe", "color_tokens_user"],
+            intent: { name: "ChangeAppSetting", id: 1 },
+            version_control_api_version: 7,
+            changelog_data: [
+              {
+                operation: "changed",
+                before_value: null,
+                after_value: null,
+                display_name: "User color tokens",
+                type: "Setting",
+                root: null,
+                change_path: "settings.client_safe.color_tokens_user.",
+                inner_nodes_info: [
+                  {
+                    change_path: "settings.client_safe.color_tokens_user.",
+                    type: "Setting",
+                    display_name: "User color tokens",
+                  },
+                ],
+                inner_node_count: 1,
+              },
+            ],
+            session_id: sessionId,
+          },
+          {
+            type: "id_counter",
+            value: 10006263, // This might need to be dynamic, but using a static value for now
+          },
+        ],
+      };
+
+      return await new Promise(function (resolve) {
+        window
+          .Lib()
+          .location.post(
+            "server://appeditor/write",
+            payload,
+            function (err, res) {
+              if (err) {
+                resolve({
+                  ok: false,
+                  error: typeof err === "string" ? err : String(err),
+                });
+              } else {
+                resolve({ ok: true, result: res });
+              }
+            },
+          );
+      });
+    } catch (e) {
+      return { ok: false, error: e && e.message ? e.message : String(e) };
+    }
+  }
+
+  // ── Actions ───────────────────────────────────────────────────────────
+
+  async function scanApp() {
+    const [activeTab] = await chrome.tabs.query({
+      active: true,
+      currentWindow: true,
+    });
+
+    if (
+      !activeTab?.id ||
+      !activeTab.url ||
+      !activeTab.url.includes("bubble.") ||
+      !activeTab.url.includes("/page")
+    ) {
+      showToolMessage(
+        "Please open a Bubble editor page (/page) first.",
+        "error",
+      );
+      return;
+    }
+
+    scanBtn.disabled = true;
+    hideToolMessage();
+
+    try {
+      const preloadCheck = await chrome.scripting.executeScript({
+        target: { tabId: activeTab.id },
+        world: "MAIN",
+        func: checkAppPreloaded,
+      });
+      if (!preloadCheck?.[0]?.result) {
+        showToolMessage(
+          'App not preloaded. Use "Optimize Application" in Bubble Settings first.',
+          "error",
+        );
+        return;
+      }
+
+      loader.hidden = false;
+      const results = await chrome.scripting.executeScript({
+        target: { tabId: activeTab.id },
+        world: "MAIN",
+        func: fetchAppRawInPage,
+      });
+      openModal(results?.[0]?.result ?? { __error: "No result from page" });
+    } catch (error) {
+      console.error("❤️ Delete unused colors scan failed:", error);
+      showToolMessage("Scan failed. Try again later.", "error");
+    } finally {
+      loader.hidden = true;
+      scanBtn.disabled = false;
+    }
+  }
+
+  async function runDeleteWrite(updatedDefault, ids) {
+    const [activeTab] = await chrome.tabs.query({
+      active: true,
+      currentWindow: true,
+    });
+    if (!activeTab?.id) {
+      hideConfirmOverlay();
+      showToolMessage("No active editor tab.", "error");
+      return;
+    }
+
+    applyBtn.disabled = true;
+    confirmOkBtn.disabled = true;
+    try {
+      const results = await chrome.scripting.executeScript({
+        target: { tabId: activeTab.id },
+        world: "MAIN",
+        func: runWriteColorVariablesInPage,
+        args: [updatedDefault],
+      });
+      const res = results?.[0]?.result;
+      hideConfirmOverlay();
+
+      if (res?.ok) {
+        lastAppRawForApply = null;
+        applyBtn.hidden = true;
+        closeModal();
+        const n = ids.length;
+        showToolMessage(
+          `Done. ${n} color${n > 1 ? "s" : ""} removed from the variables.`,
+          "success",
+        );
+      } else {
+        console.error("❤️ Delete unused colors write failed:", res?.error);
+        closeModal();
+        showToolMessage("Could not save changes. Try again later.", "error");
+      }
+    } catch (err) {
+      console.error("❤️ Delete unused colors write failed:", err);
+      hideConfirmOverlay();
+      closeModal();
+      showToolMessage("Could not save changes. Try again later.", "error");
+    } finally {
+      applyBtn.disabled = false;
+      confirmOkBtn.disabled = false;
+      updateApplyButtonVisibility();
+    }
+  }
+
+  function handleApplyClick() {
+    if (!lastAppRawForApply) {
+      showToolMessage("Run a scan first.", "error");
+      return;
+    }
+    const ids = Array.from(
+      unusedList.querySelectorAll(".duc-unused-item-cb:checked"),
+    )
+      .map((c) => c.dataset.tokenId)
+      .filter(Boolean);
+
+    if (ids.length === 0) {
+      showToolMessage("Select at least one color to remove.", "error");
+      return;
+    }
+
+    const updatedDefault = buildColorsVariablesSoftDeleted(
+      lastAppRawForApply,
+      ids,
+    );
+    if (!updatedDefault) {
+      console.error(
+        "❤️ Delete unused colors: could not build write payload from last scan",
+      );
+      showToolMessage("Could not prepare the changes.", "error");
+      return;
+    }
+
+    const label = ids.length === 1 ? "1 color" : `${ids.length} colors`;
+    pendingDelete = { updatedDefault, ids };
+    showConfirmOverlay(`Delete ${label} from the variables?`);
+  }
+
+  // ── Event listeners ───────────────────────────────────────────────────
+
+  scanBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    scanApp();
+  });
+
+  closeBtn.addEventListener("click", closeModal);
+  closeFooter.addEventListener("click", closeModal);
+  modal.addEventListener("click", (ev) => {
+    if (ev.target === modal) closeModal();
+  });
+
+  unusedSelectAll.addEventListener("change", () => {
+    const on = unusedSelectAll.checked;
+    unusedList
+      .querySelectorAll(".duc-unused-item-cb")
+      .forEach((c) => (c.checked = on));
+    unusedSelectAll.indeterminate = false;
+    updateApplyButtonVisibility();
+  });
+
+  applyBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    handleApplyClick();
+  });
+
+  confirmCancelBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    hideConfirmOverlay();
+  });
+
+  confirmOverlay.addEventListener("click", (e) => {
+    if (e.target === confirmOverlay) hideConfirmOverlay();
+  });
+
+  confirmOverlay
+    .querySelector(".duc-confirm-dialog")
+    ?.addEventListener("click", (e) => e.stopPropagation());
+
+  confirmOkBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (!pendingDelete) return;
+    const { updatedDefault, ids } = pendingDelete;
+    runDeleteWrite(updatedDefault, ids);
+  });
+
+  // ── Modal UI ──────────────────────────────────────────────────────────
+
+  function updateApplyButtonVisibility() {
+    if (!lastAppRawForApply) {
+      applyBtn.hidden = true;
+      applyBtn.disabled = true;
+      return;
+    }
+    const hasUnused =
+      unusedList.querySelectorAll(".duc-unused-item-cb").length > 0;
+    const anyChecked = !!unusedList.querySelector(
+      ".duc-unused-item-cb:checked",
+    );
+    applyBtn.hidden = !hasUnused;
+    applyBtn.disabled = !anyChecked;
+  }
+
+  function updateUnusedSelectAllState() {
+    const cbs = unusedList.querySelectorAll(".duc-unused-item-cb");
+    if (cbs.length === 0) return;
+    let checked = 0;
+    cbs.forEach((c) => {
+      if (c.checked) checked++;
+    });
+    unusedSelectAll.checked = checked === cbs.length;
+    unusedSelectAll.indeterminate = checked > 0 && checked < cbs.length;
+  }
+
+  function renderUnusedCheckboxes(unused) {
+    unusedList.innerHTML = "";
+    unusedSection.hidden = false;
+
+    if (unused.length === 0) {
+      unusedSelectAllWrap.hidden = true;
+      const empty = document.createElement("p");
+      empty.className = "duc-unused-empty";
+      empty.textContent = "No unused colors.";
+      unusedList.appendChild(empty);
+      updateApplyButtonVisibility();
+      return;
+    }
+
+    unusedSelectAllWrap.hidden = false;
+    unusedSelectAll.checked = true;
+    unusedSelectAll.indeterminate = false;
+
+    unused.forEach((token, index) => {
+      const row = document.createElement("div");
+      row.className = "duc-unused-row";
+
+      const cb = document.createElement("input");
+      cb.type = "checkbox";
+      cb.className = "duc-unused-item-cb";
+      cb.id = "duc-unused-item-" + index;
+      cb.dataset.tokenId = token.id;
+      cb.checked = true;
+      cb.addEventListener("change", () => {
+        updateUnusedSelectAllState();
+        updateApplyButtonVisibility();
+      });
+
+      const label = document.createElement("label");
+      label.htmlFor = cb.id;
+      label.textContent = token.name || token.id || "(unnamed)";
+
+      row.appendChild(cb);
+      row.appendChild(label);
+      unusedList.appendChild(row);
+    });
+
+    updateApplyButtonVisibility();
+  }
+
+  // ── Confirm overlay ───────────────────────────────────────────────────
+
+  function hideConfirmOverlay() {
+    confirmOverlay.hidden = true;
+    confirmOverlay.setAttribute("aria-hidden", "true");
+    pendingDelete = null;
+    confirmOkBtn.disabled = false;
+  }
+
+  function showConfirmOverlay(messageText) {
+    confirmMessageEl.textContent = messageText;
+    confirmOverlay.hidden = false;
+    confirmOverlay.setAttribute("aria-hidden", "false");
+    confirmOkBtn.focus();
+  }
+
+  // ── Modal open / close ────────────────────────────────────────────────
+
+  function resetModal() {
+    hideConfirmOverlay();
+    modalError.hidden = true;
+    modalError.textContent = "";
+    modalReport.hidden = true;
+    unusedHeading.textContent = "Unused colors";
+    unusedSection.hidden = true;
+    unusedList.innerHTML = "";
+    unusedSelectAllWrap.hidden = true;
+    lastAppRawForApply = null;
+    applyBtn.hidden = true;
+  }
+
+  function openModal(data) {
+    resetModal();
+    document.body.style.overflow = "hidden";
+
+    if (!data) {
+      console.error("❤️ Delete unused colors: openModal received no data");
+      modalError.textContent = "Nothing to show.";
+      modalError.hidden = false;
+      modal.hidden = false;
+      return;
+    }
+    if (data.__error) {
+      console.error("❤️ Delete unused colors: load failed", data.__error);
+      modalError.textContent =
+        "Could not load app data. Run Optimize Application, then try Scan again.";
+      modalError.hidden = false;
+      modal.hidden = false;
+      return;
+    }
+
+    const appRaw = data;
+    const report = analyzeColorVariablesUsage(appRaw);
+
+    if (report.error) {
+      console.error("❤️ Delete unused colors: analyze failed", report.error);
+      modalError.textContent =
+        "Could not analyze color variables in this app. Try again later.";
+      modalError.hidden = false;
+      modal.hidden = false;
+      return;
+    }
+
+    unusedHeading.textContent = `Unused colors (${report.unused.length})`;
+
+    try {
+      lastAppRawForApply = JSON.parse(JSON.stringify(appRaw));
+    } catch (e) {
+      console.error("❤️ Delete unused colors: could not clone app data", e);
+      lastAppRawForApply = null;
+    }
+
+    renderUnusedCheckboxes(report.unused);
+
+    modalReport.hidden = false;
+    modal.hidden = false;
+  }
+
+  function closeModal() {
+    hideConfirmOverlay();
+    modal.hidden = true;
+    document.body.style.overflow = "";
+  }
+
+  // ── Utility: inline message ───────────────────────────────────────────
+
+  function showToolMessage(text, kind) {
+    if (inlineMessageTimer) {
+      clearTimeout(inlineMessageTimer);
+      inlineMessageTimer = null;
+    }
+    inlineMessageEl.textContent = text;
+    inlineMessageEl.classList.remove(
+      "duc-inline-message--success",
+      "duc-inline-message--error",
+    );
+    if (kind === "success") {
+      inlineMessageEl.classList.add("duc-inline-message--success");
+    } else if (kind === "error") {
+      inlineMessageEl.classList.add("duc-inline-message--error");
+    }
+    inlineMessageEl.hidden = false;
+    if (kind === "success") {
+      inlineMessageTimer = setTimeout(() => {
+        inlineMessageEl.hidden = true;
+        inlineMessageEl.textContent = "";
+        inlineMessageTimer = null;
+      }, 8000);
+    }
+  }
+
+  function hideToolMessage() {
+    if (inlineMessageTimer) {
+      clearTimeout(inlineMessageTimer);
+      inlineMessageTimer = null;
+    }
+    inlineMessageEl.hidden = true;
+    inlineMessageEl.textContent = "";
+    inlineMessageEl.classList.remove(
+      "duc-inline-message--success",
+      "duc-inline-message--error",
+    );
+  }
+})();

--- a/features/delete_unused_colors/readme.md
+++ b/features/delete_unused_colors/readme.md
@@ -1,0 +1,33 @@
+# Delete Unused Colors
+
+Contributed by Thomas Mey (https://www.linkedin.com/in/thomas-mey97/)
+
+Delete Unused Colors scans your Bubble app for color variables that are not referenced anywhere, and lets you soft-delete them in bulk from the Powerup extension popup.
+
+This feature complements Bubble's built-in **Optimize Application**: that step preloads the full app JSON, but it does not identify or remove unused color variables. This tool fills that gap.
+
+## Prerequisites
+
+This feature does **not** trigger a full app load itself. The complete JSON must already be in memory before scanning. Use Bubble's built-in **Optimize Application** (available in Bubble Settings) to preload the app data first.
+
+Why not load the JSON ourselves? Loading the entire app into memory is a heavy operation that can freeze the browser and spike server load on large apps. We deliberately avoid taking responsibility for that: the user should consciously trigger it via Bubble's official tool, rather than having the extension silently do it in the background when they click "Scan".
+
+The extension checks `appquery().app().json._ready_key.is_turned()` to verify the JSON is already fully loaded before allowing a scan.
+
+## How It Works
+
+- Open your Bubble editor.
+- Run **Optimize Application** from Bubble Settings so the full app JSON is loaded in memory.
+- Click the Powerup extension icon in your browser.
+- In the popup, scroll down to "Delete Unused Colors" and click **Scan app**.
+- The extension reads User Colors Variables, skips tokens already marked as `deleted`, and checks whether each remaining token's variable appears anywhere else in the app JSON.
+- Select the unused colors you want to remove and confirm.
+- Selected tokens are **soft-deleted** (`deleted: true`), which means they can still be restored from the Bubble editor.
+
+## Why Soft Delete
+
+Soft delete is the safer approach: tokens are flagged as deleted but remain in the JSON, so Bubble can restore them if needed, or if the colors was flagged as "unused" by error. This is already useful for cleaning up unused styles and keeping the variables manageable.
+
+A hard delete (removing tokens entirely from the JSON) could be implemented later for better app optimization, but soft delete covers the common cleanup use case without risk.
+
+[⬆️ Back to root directory](../../)

--- a/popup.js
+++ b/popup.js
@@ -9,7 +9,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     "rico": { name: "Rico Trevisan", link: "https://www.mocharymethod.com/team/rico-trevisan" },
     "george": { name: "George Collier", link: "https://notquiteunicorns.xyz/" },
     "tim": { name: "Timothy Tu", link: "https://community.buildcamp.io/u/b0c0b288" },
-    "rafa": { name: "Rafa Chavantes", link: "https://rafa.chavantes.com/" }
+    "rafa": { name: "Rafa Chavantes", link: "https://rafa.chavantes.com/" },
+    thomas: { name: "Thomas Mey", link: "https://www.linkedin.com/in/thomas-mey-dev/", },
   };
 
   // Helper: Promisified chrome.storage.sync.get
@@ -47,7 +48,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   let domainState = "Unrelated";
   let currentDomain = "";
   let currentPath = "";
-  chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     if (!tabs || !tabs[0] || !tabs[0].url) return;
     try {
       const url = new URL(tabs[0].url);
@@ -135,7 +136,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const originalPrefs = JSON.parse(JSON.stringify(prefs));
   // Track whether changes have been made
   let changesMade = false;
-  let applyFiltersRef = () => {};
+  let applyFiltersRef = () => { };
 
   const container = document.getElementById("features-list");
 
@@ -190,7 +191,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     feature.config.inputs.forEach(inputConfig => {
       // Get the stored value or use default
-      chrome.storage.sync.get([inputConfig.key], function(result) {
+      chrome.storage.sync.get([inputConfig.key], function (result) {
         const value = result[inputConfig.key] !== undefined ? result[inputConfig.key] : inputConfig.default;
 
         // Create input container
@@ -233,8 +234,8 @@ document.addEventListener("DOMContentLoaded", async () => {
         input.addEventListener("change", () => {
           // Store the value in chrome.storage
           const newValue = input.type === "checkbox" ? input.checked :
-                          input.type === "number" ? parseInt(input.value, 10) :
-                          input.value;
+            input.type === "number" ? parseInt(input.value, 10) :
+              input.value;
 
           const storageUpdate = {};
           storageUpdate[inputConfig.key] = newValue;
@@ -406,7 +407,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     div.addEventListener("click", (event) => {
       // Prevent default behavior for label and span elements
       if (event.target.tagName === 'LABEL' ||
-          (event.target.tagName === 'SPAN' && event.target.parentElement && event.target.parentElement.tagName === 'LABEL')) {
+        (event.target.tagName === 'SPAN' && event.target.parentElement && event.target.parentElement.tagName === 'LABEL')) {
         event.preventDefault();
       }
 
@@ -415,8 +416,8 @@ document.addEventListener("DOMContentLoaded", async () => {
 
       // Don't toggle if clicking on an input field or its label
       if (event.target.tagName === 'INPUT' ||
-          (event.target.tagName === 'LABEL' && event.target.closest('.input-container')) ||
-          event.target.closest('.input-container')) {
+        (event.target.tagName === 'LABEL' && event.target.closest('.input-container')) ||
+        event.target.closest('.input-container')) {
         return;
       }
 
@@ -437,8 +438,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     const cards = Array.from(accordion.querySelectorAll(".feature:not(.sub-feature)"));
     const total = cards.length;
     const enabledCount = cards.filter((card) => {
-        const checkbox = card.querySelector('input[type="checkbox"]');
-        return checkbox && !checkbox.disabled && checkbox.checked;
+      const checkbox = card.querySelector('input[type="checkbox"]');
+      return checkbox && !checkbox.disabled && checkbox.checked;
     }).length;
     const countEl = accordion.querySelector(".category-count");
     if (countEl) {
@@ -470,18 +471,18 @@ document.addEventListener("DOMContentLoaded", async () => {
 
       const countSpan = document.createElement("span");
       countSpan.className = "category-count";
-      
+
       trigger.appendChild(titleSpan);
       trigger.appendChild(countSpan);
       trigger.insertAdjacentHTML(
-          "beforeend",
-          '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
+        "beforeend",
+        '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
       );
 
       trigger.addEventListener("click", () => {
-          const isOpen = accordion.dataset.state === "open";
-          accordion.dataset.state = isOpen ? "closed" : "open";
-          trigger.setAttribute("aria-expanded", String(!isOpen));
+        const isOpen = accordion.dataset.state === "open";
+        accordion.dataset.state = isOpen ? "closed" : "open";
+        trigger.setAttribute("aria-expanded", String(!isOpen));
       });
 
       const content = document.createElement("div");
@@ -513,10 +514,10 @@ document.addEventListener("DOMContentLoaded", async () => {
       });
 
       if (content.children.length > 0) {
-          accordion.appendChild(trigger);
-          accordion.appendChild(content);
-          container.appendChild(accordion);
-          updateCategoryCount(accordion);
+        accordion.appendChild(trigger);
+        accordion.appendChild(content);
+        container.appendChild(accordion);
+        updateCategoryCount(accordion);
       }
     }
   });
@@ -685,78 +686,78 @@ document.addEventListener("DOMContentLoaded", async () => {
       const query = searchInput.value.toLowerCase().trim();
 
       document.querySelectorAll(".accordion").forEach((section) => {
-          const categoryName = section.dataset.category.toLowerCase();
-          const categoryMatches = query ? categoryName.includes(query) : false;
+        const categoryName = section.dataset.category.toLowerCase();
+        const categoryMatches = query ? categoryName.includes(query) : false;
 
-          const cards = Array.from(section.querySelectorAll(".feature"));
-          const visibility = new Map();
+        const cards = Array.from(section.querySelectorAll(".feature"));
+        const visibility = new Map();
 
-          // Pass 1: Determine initial visibility for all features
-          cards.forEach(card => {
-              const checkbox = card.querySelector('input[type="checkbox"]');
-              const featureKey = checkbox?.id;
-              if (!featureKey) return;
+        // Pass 1: Determine initial visibility for all features
+        cards.forEach(card => {
+          const checkbox = card.querySelector('input[type="checkbox"]');
+          const featureKey = checkbox?.id;
+          if (!featureKey) return;
 
-              const featureData = features.find(f => f.key === featureKey);
-              if (!featureData) return;
+          const featureData = features.find(f => f.key === featureKey);
+          if (!featureData) return;
 
-              const title = (featureData.name || "").toLowerCase();
-              const desc = (featureData.description || "").toLowerCase();
-              const isEnabled = checkbox.checked;
+          const title = (featureData.name || "").toLowerCase();
+          const desc = (featureData.description || "").toLowerCase();
+          const isEnabled = checkbox.checked;
 
-              let isVisible;
-              if (categoryMatches) {
-                  isVisible = true;
-              } else {
-                  isVisible = query ? (title.includes(query) || desc.includes(query)) : true;
-              }
-              if (isVisible && currentFilter === "enabled") isVisible = isEnabled;
-              if (isVisible && currentFilter === "disabled") isVisible = !isEnabled;
+          let isVisible;
+          if (categoryMatches) {
+            isVisible = true;
+          } else {
+            isVisible = query ? (title.includes(query) || desc.includes(query)) : true;
+          }
+          if (isVisible && currentFilter === "enabled") isVisible = isEnabled;
+          if (isVisible && currentFilter === "disabled") isVisible = !isEnabled;
 
-              visibility.set(featureKey, isVisible);
-          });
+          visibility.set(featureKey, isVisible);
+        });
 
-          // Pass 2: If a sub-feature is visible, ensure its parent is also visible
-          cards.forEach(card => {
-              const checkbox = card.querySelector('input[type="checkbox"]');
-              const featureKey = checkbox?.id;
-              if (!featureKey) return;
+        // Pass 2: If a sub-feature is visible, ensure its parent is also visible
+        cards.forEach(card => {
+          const checkbox = card.querySelector('input[type="checkbox"]');
+          const featureKey = checkbox?.id;
+          if (!featureKey) return;
 
-              const featureData = features.find(f => f.key === featureKey);
-              if (!featureData || !isSubFeature(featureData)) return;
+          const featureData = features.find(f => f.key === featureKey);
+          if (!featureData || !isSubFeature(featureData)) return;
 
-              if (visibility.get(featureKey)) { // if sub-feature is visible
-                  const parentKey = featureData.requires;
-                  if (parentKey) {
-                      visibility.set(parentKey, true); // force parent to be visible
-                  }
-              }
-          });
+          if (visibility.get(featureKey)) { // if sub-feature is visible
+            const parentKey = featureData.requires;
+            if (parentKey) {
+              visibility.set(parentKey, true); // force parent to be visible
+            }
+          }
+        });
 
-          let visibleCount = 0;
-          // Pass 3: Apply visibility to DOM and update counts
-          cards.forEach(card => {
-              const checkbox = card.querySelector('input[type="checkbox"]');
-              const featureKey = checkbox?.id;
-              if (!featureKey) return;
+        let visibleCount = 0;
+        // Pass 3: Apply visibility to DOM and update counts
+        cards.forEach(card => {
+          const checkbox = card.querySelector('input[type="checkbox"]');
+          const featureKey = checkbox?.id;
+          if (!featureKey) return;
 
-              const isVisible = visibility.get(featureKey);
-              card.style.display = isVisible ? '' : 'none';
+          const isVisible = visibility.get(featureKey);
+          card.style.display = isVisible ? '' : 'none';
 
-              if (isVisible && !card.classList.contains('sub-feature')) {
-                  visibleCount++;
-              }
-          });
-          
-          // Also need to hide/show the .sub-features containers
-          section.querySelectorAll('.sub-features').forEach(container => {
-              const hasVisibleChild = Array.from(container.querySelectorAll('.feature.sub-feature')).some(
-                  child => child.style.display !== 'none'
-              );
-              container.style.display = hasVisibleChild ? '' : 'none';
-          });
+          if (isVisible && !card.classList.contains('sub-feature')) {
+            visibleCount++;
+          }
+        });
 
-          section.style.display = visibleCount > 0 ? 'block' : 'none';
+        // Also need to hide/show the .sub-features containers
+        section.querySelectorAll('.sub-features').forEach(container => {
+          const hasVisibleChild = Array.from(container.querySelectorAll('.feature.sub-feature')).some(
+            child => child.style.display !== 'none'
+          );
+          container.style.display = hasVisibleChild ? '' : 'none';
+        });
+
+        section.style.display = visibleCount > 0 ? 'block' : 'none';
       });
     };
 
@@ -764,12 +765,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     searchInput.addEventListener("input", applyFilters);
 
     filterBtns.forEach((btn) => {
-        btn.addEventListener("click", () => {
-            filterBtns.forEach((b) => b.removeAttribute('data-state'));
-            btn.dataset.state = "active";
-            currentFilter = btn.dataset.filter;
-            applyFilters();
-        });
+      btn.addEventListener("click", () => {
+        filterBtns.forEach((b) => b.removeAttribute('data-state'));
+        btn.dataset.state = "active";
+        currentFilter = btn.dataset.filter;
+        applyFilters();
+      });
     });
   }
 
@@ -788,7 +789,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         link.href = chrome.runtime.getURL(message.cssFile);
         document.head.appendChild(link);
       }
-      
+
       // Load JS if provided
       if (message.jsFile) {
         const script = document.createElement('script');
@@ -797,7 +798,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         script.className = '❤️injected-script';
         document.head.appendChild(script);
       }
-      
+
       sendResponse({ success: true });
     }
   });

--- a/popup.js
+++ b/popup.js
@@ -10,7 +10,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     "george": { name: "George Collier", link: "https://notquiteunicorns.xyz/" },
     "tim": { name: "Timothy Tu", link: "https://community.buildcamp.io/u/b0c0b288" },
     "rafa": { name: "Rafa Chavantes", link: "https://rafa.chavantes.com/" },
-    thomas: { name: "Thomas Mey", link: "https://www.linkedin.com/in/thomas-mey-dev/", },
+    "thomas": { name: "Thomas Mey", link: "https://www.linkedin.com/in/thomas-mey-dev/", },
   };
 
   // Helper: Promisified chrome.storage.sync.get
@@ -48,7 +48,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   let domainState = "Unrelated";
   let currentDomain = "";
   let currentPath = "";
-  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+  chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
     if (!tabs || !tabs[0] || !tabs[0].url) return;
     try {
       const url = new URL(tabs[0].url);
@@ -136,7 +136,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const originalPrefs = JSON.parse(JSON.stringify(prefs));
   // Track whether changes have been made
   let changesMade = false;
-  let applyFiltersRef = () => { };
+  let applyFiltersRef = () => {};
 
   const container = document.getElementById("features-list");
 
@@ -191,7 +191,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     feature.config.inputs.forEach(inputConfig => {
       // Get the stored value or use default
-      chrome.storage.sync.get([inputConfig.key], function (result) {
+      chrome.storage.sync.get([inputConfig.key], function(result) {
         const value = result[inputConfig.key] !== undefined ? result[inputConfig.key] : inputConfig.default;
 
         // Create input container
@@ -234,8 +234,8 @@ document.addEventListener("DOMContentLoaded", async () => {
         input.addEventListener("change", () => {
           // Store the value in chrome.storage
           const newValue = input.type === "checkbox" ? input.checked :
-            input.type === "number" ? parseInt(input.value, 10) :
-              input.value;
+                          input.type === "number" ? parseInt(input.value, 10) :
+                          input.value;
 
           const storageUpdate = {};
           storageUpdate[inputConfig.key] = newValue;
@@ -407,7 +407,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     div.addEventListener("click", (event) => {
       // Prevent default behavior for label and span elements
       if (event.target.tagName === 'LABEL' ||
-        (event.target.tagName === 'SPAN' && event.target.parentElement && event.target.parentElement.tagName === 'LABEL')) {
+          (event.target.tagName === 'SPAN' && event.target.parentElement && event.target.parentElement.tagName === 'LABEL')) {
         event.preventDefault();
       }
 
@@ -416,8 +416,8 @@ document.addEventListener("DOMContentLoaded", async () => {
 
       // Don't toggle if clicking on an input field or its label
       if (event.target.tagName === 'INPUT' ||
-        (event.target.tagName === 'LABEL' && event.target.closest('.input-container')) ||
-        event.target.closest('.input-container')) {
+          (event.target.tagName === 'LABEL' && event.target.closest('.input-container')) ||
+          event.target.closest('.input-container')) {
         return;
       }
 
@@ -438,8 +438,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     const cards = Array.from(accordion.querySelectorAll(".feature:not(.sub-feature)"));
     const total = cards.length;
     const enabledCount = cards.filter((card) => {
-      const checkbox = card.querySelector('input[type="checkbox"]');
-      return checkbox && !checkbox.disabled && checkbox.checked;
+        const checkbox = card.querySelector('input[type="checkbox"]');
+        return checkbox && !checkbox.disabled && checkbox.checked;
     }).length;
     const countEl = accordion.querySelector(".category-count");
     if (countEl) {
@@ -471,18 +471,18 @@ document.addEventListener("DOMContentLoaded", async () => {
 
       const countSpan = document.createElement("span");
       countSpan.className = "category-count";
-
+      
       trigger.appendChild(titleSpan);
       trigger.appendChild(countSpan);
       trigger.insertAdjacentHTML(
-        "beforeend",
-        '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
+          "beforeend",
+          '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
       );
 
       trigger.addEventListener("click", () => {
-        const isOpen = accordion.dataset.state === "open";
-        accordion.dataset.state = isOpen ? "closed" : "open";
-        trigger.setAttribute("aria-expanded", String(!isOpen));
+          const isOpen = accordion.dataset.state === "open";
+          accordion.dataset.state = isOpen ? "closed" : "open";
+          trigger.setAttribute("aria-expanded", String(!isOpen));
       });
 
       const content = document.createElement("div");
@@ -514,10 +514,10 @@ document.addEventListener("DOMContentLoaded", async () => {
       });
 
       if (content.children.length > 0) {
-        accordion.appendChild(trigger);
-        accordion.appendChild(content);
-        container.appendChild(accordion);
-        updateCategoryCount(accordion);
+          accordion.appendChild(trigger);
+          accordion.appendChild(content);
+          container.appendChild(accordion);
+          updateCategoryCount(accordion);
       }
     }
   });
@@ -686,78 +686,78 @@ document.addEventListener("DOMContentLoaded", async () => {
       const query = searchInput.value.toLowerCase().trim();
 
       document.querySelectorAll(".accordion").forEach((section) => {
-        const categoryName = section.dataset.category.toLowerCase();
-        const categoryMatches = query ? categoryName.includes(query) : false;
+          const categoryName = section.dataset.category.toLowerCase();
+          const categoryMatches = query ? categoryName.includes(query) : false;
 
-        const cards = Array.from(section.querySelectorAll(".feature"));
-        const visibility = new Map();
+          const cards = Array.from(section.querySelectorAll(".feature"));
+          const visibility = new Map();
 
-        // Pass 1: Determine initial visibility for all features
-        cards.forEach(card => {
-          const checkbox = card.querySelector('input[type="checkbox"]');
-          const featureKey = checkbox?.id;
-          if (!featureKey) return;
+          // Pass 1: Determine initial visibility for all features
+          cards.forEach(card => {
+              const checkbox = card.querySelector('input[type="checkbox"]');
+              const featureKey = checkbox?.id;
+              if (!featureKey) return;
 
-          const featureData = features.find(f => f.key === featureKey);
-          if (!featureData) return;
+              const featureData = features.find(f => f.key === featureKey);
+              if (!featureData) return;
 
-          const title = (featureData.name || "").toLowerCase();
-          const desc = (featureData.description || "").toLowerCase();
-          const isEnabled = checkbox.checked;
+              const title = (featureData.name || "").toLowerCase();
+              const desc = (featureData.description || "").toLowerCase();
+              const isEnabled = checkbox.checked;
 
-          let isVisible;
-          if (categoryMatches) {
-            isVisible = true;
-          } else {
-            isVisible = query ? (title.includes(query) || desc.includes(query)) : true;
-          }
-          if (isVisible && currentFilter === "enabled") isVisible = isEnabled;
-          if (isVisible && currentFilter === "disabled") isVisible = !isEnabled;
+              let isVisible;
+              if (categoryMatches) {
+                  isVisible = true;
+              } else {
+                  isVisible = query ? (title.includes(query) || desc.includes(query)) : true;
+              }
+              if (isVisible && currentFilter === "enabled") isVisible = isEnabled;
+              if (isVisible && currentFilter === "disabled") isVisible = !isEnabled;
 
-          visibility.set(featureKey, isVisible);
-        });
+              visibility.set(featureKey, isVisible);
+          });
 
-        // Pass 2: If a sub-feature is visible, ensure its parent is also visible
-        cards.forEach(card => {
-          const checkbox = card.querySelector('input[type="checkbox"]');
-          const featureKey = checkbox?.id;
-          if (!featureKey) return;
+          // Pass 2: If a sub-feature is visible, ensure its parent is also visible
+          cards.forEach(card => {
+              const checkbox = card.querySelector('input[type="checkbox"]');
+              const featureKey = checkbox?.id;
+              if (!featureKey) return;
 
-          const featureData = features.find(f => f.key === featureKey);
-          if (!featureData || !isSubFeature(featureData)) return;
+              const featureData = features.find(f => f.key === featureKey);
+              if (!featureData || !isSubFeature(featureData)) return;
 
-          if (visibility.get(featureKey)) { // if sub-feature is visible
-            const parentKey = featureData.requires;
-            if (parentKey) {
-              visibility.set(parentKey, true); // force parent to be visible
-            }
-          }
-        });
+              if (visibility.get(featureKey)) { // if sub-feature is visible
+                  const parentKey = featureData.requires;
+                  if (parentKey) {
+                      visibility.set(parentKey, true); // force parent to be visible
+                  }
+              }
+          });
 
-        let visibleCount = 0;
-        // Pass 3: Apply visibility to DOM and update counts
-        cards.forEach(card => {
-          const checkbox = card.querySelector('input[type="checkbox"]');
-          const featureKey = checkbox?.id;
-          if (!featureKey) return;
+          let visibleCount = 0;
+          // Pass 3: Apply visibility to DOM and update counts
+          cards.forEach(card => {
+              const checkbox = card.querySelector('input[type="checkbox"]');
+              const featureKey = checkbox?.id;
+              if (!featureKey) return;
 
-          const isVisible = visibility.get(featureKey);
-          card.style.display = isVisible ? '' : 'none';
+              const isVisible = visibility.get(featureKey);
+              card.style.display = isVisible ? '' : 'none';
 
-          if (isVisible && !card.classList.contains('sub-feature')) {
-            visibleCount++;
-          }
-        });
+              if (isVisible && !card.classList.contains('sub-feature')) {
+                  visibleCount++;
+              }
+          });
+          
+          // Also need to hide/show the .sub-features containers
+          section.querySelectorAll('.sub-features').forEach(container => {
+              const hasVisibleChild = Array.from(container.querySelectorAll('.feature.sub-feature')).some(
+                  child => child.style.display !== 'none'
+              );
+              container.style.display = hasVisibleChild ? '' : 'none';
+          });
 
-        // Also need to hide/show the .sub-features containers
-        section.querySelectorAll('.sub-features').forEach(container => {
-          const hasVisibleChild = Array.from(container.querySelectorAll('.feature.sub-feature')).some(
-            child => child.style.display !== 'none'
-          );
-          container.style.display = hasVisibleChild ? '' : 'none';
-        });
-
-        section.style.display = visibleCount > 0 ? 'block' : 'none';
+          section.style.display = visibleCount > 0 ? 'block' : 'none';
       });
     };
 
@@ -765,12 +765,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     searchInput.addEventListener("input", applyFilters);
 
     filterBtns.forEach((btn) => {
-      btn.addEventListener("click", () => {
-        filterBtns.forEach((b) => b.removeAttribute('data-state'));
-        btn.dataset.state = "active";
-        currentFilter = btn.dataset.filter;
-        applyFilters();
-      });
+        btn.addEventListener("click", () => {
+            filterBtns.forEach((b) => b.removeAttribute('data-state'));
+            btn.dataset.state = "active";
+            currentFilter = btn.dataset.filter;
+            applyFilters();
+        });
     });
   }
 
@@ -789,7 +789,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         link.href = chrome.runtime.getURL(message.cssFile);
         document.head.appendChild(link);
       }
-
+      
       // Load JS if provided
       if (message.jsFile) {
         const script = document.createElement('script');
@@ -798,7 +798,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         script.className = '❤️injected-script';
         document.head.appendChild(script);
       }
-
+      
       sendResponse({ success: true });
     }
   });

--- a/popup.js
+++ b/popup.js
@@ -10,7 +10,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     "george": { name: "George Collier", link: "https://notquiteunicorns.xyz/" },
     "tim": { name: "Timothy Tu", link: "https://community.buildcamp.io/u/b0c0b288" },
     "rafa": { name: "Rafa Chavantes", link: "https://rafa.chavantes.com/" },
-    "thomas": { name: "Thomas Mey", link: "https://www.linkedin.com/in/thomas-mey-dev/", },
+    "thomas": { name: "Thomas Mey", link: "https://www.linkedin.com/in/thomas-mey-dev/" },
   };
 
   // Helper: Promisified chrome.storage.sync.get


### PR DESCRIPTION
### Summary

This PR adds **Delete Unused Colors**, a Style-tab feature that scans a preloaded Bubble app for **user color variables** that are not referenced anywhere in the app JSON, lists them in a modal from the extension popup, and lets the user **soft-delete** selected variables in bulk.

It complements Bubble's built-in **Optimize Application**, which preloads the full JSON but does not identify or clean unused color variables.

### Features Added

#### Delete Unused Colors

- Access from the extension popup while on a Bubble editor page (`/page`).
- **Scan app** after the app JSON is preloaded via **Optimize Application** (Bubble Settings).
- Readiness check via `appquery().app().json._ready_key.is_turned()` before scanning.
- Lists unused colors with checkboxes; select all / unselect all.
- Confirmation dialog before applying changes.
- **Soft-delete** (`deleted: true`) so variables can still be recovered in the Bubble editor.
- Skips tokens already marked as deleted; analysis searches the rest of the app JSON for references (per implementation in `delete_unused_colors_popup.js`).
- User-facing error hints in the UI; technical details logged with `console.log` for debugging.


### Testing

- Scan without preloading → expected **Optimize Application** / preload messaging.
- Scan after **Optimize** → modal lists unused colors as expected.
- Scan while **Optimize** is still running → `appquery().app().json._ready_key.is_turned()` stays false until the app JSON is fully loaded; the same preload messaging appears as expected.
- App with no unused colors → empty state.
- Partial selection and “select all” → apply only affects chosen tokens.
- Cancel on confirmation → no write; modal state OK.
- Confirm apply → soft-delete reflected in Bubble; success message in popup.
- Failure paths → short UI copy; details in the browser console.
- Bubble **Undo** → colors are restored as non-deleted (consistent with other editor operations).

### Why This Feature?

- Unused color variables accumulate and clutter the palette; Bubble does not offer this cleanup in Optimize Application.
- New apps ship with default color variables that are often unnecessary; there was no quick way to bulk-remove them for a clean slate.
- Soft-delete keeps recovery possible while still cleaning the active variable list.

### Why not load the JSON ourselves? 

Loading the entire app into memory is a heavy operation that can freeze the browser and spike server load on large apps. We deliberately avoid taking responsibility for that: the user should consciously trigger it via Bubble's official tool **Optimize Application**, rather than having the extension silently do it in the background when they click "Scan".

### Why Soft Delete ?

Soft delete is the safer approach: tokens are flagged as deleted but remain in the JSON, so Bubble can restore them if needed, or if the colors was flagged as "unused" by error. This is already useful for cleaning up unused styles and keeping the variables manageable.

A hard delete (removing tokens entirely from the JSON) could be implemented later for better app optimization, but soft delete covers the common cleanup use case without risk.

### Compatibility

- Targets the current Bubble editor; requires an editor tab and preloaded JSON.
- Styles category
- Enabled by default
- Follows all codebase convention

### Notes

- The feature Opt-in/checkbox doesn't change anything; nothing is injected into the editor page itself before a scan is initiated by click on the scan button on the popup.
- **Style tab refresh:** Bubble’s UI for Color Variables can lag behind the real data. If you stay on the Style tab while running a cleanup (or while using Bubble’s Undo), a soft-deleted color may still appear in the list until you leave the Style tab and open it again. The same happens when you delete a color manually and undo. The issue is not specific to this extension, but on Bubble side.

---

Thank you for considering this contribution. Happy to adjust based on review feedback.
